### PR TITLE
Adding arxiv.org/abs/2401.02801 paper to the list

### DIFF
--- a/papers/AddankiPS24credence.yml
+++ b/papers/AddankiPS24credence.yml
@@ -1,0 +1,13 @@
+title: "Credence: Augmenting Datacenter Switch Buffer Sharing with ML Predictions"
+authors: Addanki, Pacut, Schmid
+publications:
+  - name: NSDI
+    year: 2024
+  - name: arXiv
+    year: 2024
+    url: https://arxiv.org/pdf/2401.02801.pdf
+labels:
+  - online
+  - queuing
+  - buffer sharing
+  - communication networks


### PR DESCRIPTION
Adding a paper to the list.

Credence: Augmenting Datacenter Switch Buffer Sharing with ML Predictions
by Addanki, Pacut, Schmid
USENIX NSDI 2024 

The paper designs and analyzes an online algorithm with predictions for a well-known problem of online buffer sharing (studied e.g. at ICALP 2021, SPAA 2007 and SPAA 2001). The paper was accepted at USENIX NSDI 2024.