### PR TITLE
Add a new paper accepted by NeurIPS '24

### DIFF
--- a/papers/hliangzhao24pfsum.yml
+++ b/papers/hliangzhao24pfsum.yml
@@ -1,0 +1,20 @@
+title: Learning-Augmented Algorithms for the Bahncard Problem
+authors: Zhao, Tang, Chen, Deng
+labels:
+- Bahncard
+- rent-or-buy
+publications:
+- name: arXiv
+  url: https://arxiv.org/abs/2410.15257
+  year: 2024
+  month: null
+  day: null
+  dblp_key: null
+  bibtex: null
+- name: NeurIPS
+  url: https://arxiv.org/abs/2410.15257
+  year: 2024
+  month: null
+  day: null
+  dblp_key: null
+  bibtex: null


### PR DESCRIPTION
Add a new paper accepted by NeurIPS '24: Hailiang Zhao, Xueyan Tang, Peng Chen, and Shuiguang Deng, [Learning-Augmented Algorithms for the Bahncard Problem](https://arxiv.org/abs/2410.15257). Accepted to appear in the 38th Conference on Neural Information Processing Systems (NeurIPS '24).