### PR TITLE
Add four papers from ICLR and NeurIPS

### DIFF
--- a/papers/Jiang26atlas-learningaugmented-scheduling.yml
+++ b/papers/Jiang26atlas-learningaugmented-scheduling.yml
@@ -1,0 +1,21 @@
+title: 'ATLAS: Alibaba Dataset and Benchmark for Learning-Augmented Scheduling'
+authors: Zhiyun Jiang, Tianming Zhao, Chunqiu Xia, Albert Y. Zomaya
+labels:
+- experimental evaluation
+- scheduling
+publications:
+- name: ICLR
+  url: https://openreview.net/forum?id=QBvxXzHdZx
+  year: 2026
+  bibtex: |
+    @inproceedings{JiangZ26ATLAS,
+      author    = {Zhiyun Jiang and
+                   Tianming Zhao and
+                   Chunqiu Xia and
+                   Albert Y. Zomaya},
+      title     = {{ATLAS}: Alibaba Dataset and Benchmark for Learning-Augmented Scheduling},
+      booktitle = {The Fourteenth International Conference on Learning Representations},
+      year      = {2026},
+      publisher = {OpenReview.net},
+      url       = {https://openreview.net/forum?id=QBvxXzHdZx}
+    }

--- a/papers/Zhang25online-portfolio-selection.yml
+++ b/papers/Zhang25online-portfolio-selection.yml
@@ -1,0 +1,35 @@
+title: Online Portfolio Selection with ML Predictions
+authors: Ziliang Zhang, Tianming Zhao, Albert Y. Zomaya
+labels:
+- online
+publications:
+- name: NeurIPS
+  url: https://papers.neurips.cc/paper_files/paper/2025/hash/76981cb7a06b5ad53639f5bbe9924388-Abstract-Conference.html
+  year: 2025
+  dblp_key: conf/nips/ZhangZZ25
+  bibtex: |
+    @inproceedings{DBLP:conf/nips/ZhangZZ25,
+      author       = {Ziliang Zhang and
+                      Tianming Zhao and
+                      Albert Y. Zomaya},
+      editor       = {Danielle Belgrave and
+                      Cheng Zhang and
+                      Laura N. Montoya and
+                      Hsuan{-}Tien Lin and
+                      Razvan Pascanu and
+                      Piotr Koniusz and
+                      Marzyeh Ghassemi and
+                      Nancy Chen and
+                      Iv{\'{a}}n Vladimir Meza Ru{\'{\i}}z and
+                      Arturo Loaiza{-}Bonilla},
+      title        = {Online Portfolio Selection with {ML} Predictions},
+      booktitle    = {Advances in Neural Information Processing Systems 38:
+                      Annual Conference on Neural Information Processing Systems 2025,
+                      NeurIPS 2025, San Diego, CA, USA, December 2-7, 2025 /
+                      Mexico City, Mexico, November 30 - December 5, 2025},
+      year         = {2025},
+      url          = {http://papers.nips.cc/paper_files/paper/2025/hash/76981cb7a06b5ad53639f5bbe9924388-Abstract-Conference.html},
+      timestamp    = {Fri, 10 Jul 2026 07:39:50 +0200},
+      biburl       = {https://dblp.org/rec/conf/nips/ZhangZZ25.bib},
+      bibsource    = {dblp computer science bibliography, https://dblp.org}
+    }

--- a/papers/Zhao22uniform-machine-scheduling.yml
+++ b/papers/Zhao22uniform-machine-scheduling.yml
@@ -26,4 +26,8 @@ publications:
     \ and\n  Wei Li and\n  Albert Y. Zomaya},\n  title        = {Uniform Machine Scheduling\
     \ with Predictions},\n  booktitle    = {{ICAPS}},\n  pages        = {413--422},\n\
     \  publisher    = {{AAAI} Press},\n  year         = {2022}\n}\n"
+- name: IEEE Trans. Computers
+  url: https://doi.org/10.1109/TC.2024.3441856
+  year: 2024
+  bibtex: "@article{Zhao_2024,\n  author    = {Tianming Zhao and Wei Li and Albert Y. Zomaya},\n  title     = {Learning-Augmented Scheduling},\n  journal   = {IEEE Transactions on Computers},\n  volume    = {73},\n  number    = {11},\n  pages     = {2548--2562},\n  year      = {2024},\n  month     = nov,\n  doi       = {10.1109/TC.2024.3441856},\n  url       = {https://doi.org/10.1109/TC.2024.3441856}\n}\n"
 s2_id: 5e8fdfa2ed2cfdf4fe002c5afe083d33993dd1b6

--- a/papers/Zhao25competitive-fair-scheduling.yml
+++ b/papers/Zhao25competitive-fair-scheduling.yml
@@ -1,0 +1,28 @@
+title: Competitive Fair Scheduling with Predictions
+authors: Tianming Zhao, Chunqiu Xia, Xiaomin Chang, Chunhao Li, Wei Li, Albert Y. Zomaya
+labels:
+- online
+- scheduling
+publications:
+- name: ICLR
+  url: https://proceedings.iclr.cc/paper_files/paper/2025/hash/a6927363c85138bf64e2450b1d105a2b-Abstract-Conference.html
+  year: 2025
+  dblp_key: conf/iclr/0002XCL0Z25
+  bibtex: |
+    @inproceedings{DBLP:conf/iclr/0002XCL0Z25,
+      author       = {Tianming Zhao and
+                      Chunqiu Xia and
+                      Xiaomin Chang and
+                      Chunhao Li and
+                      Wei Li and
+                      Albert Y. Zomaya},
+      title        = {Competitive Fair Scheduling with Predictions},
+      booktitle    = {The Thirteenth International Conference on Learning Representations,
+                      {ICLR} 2025, Singapore, April 24-28, 2025},
+      publisher    = {OpenReview.net},
+      year         = {2025},
+      url          = {https://openreview.net/forum?id=jBYQAtzp5Z},
+      timestamp    = {Thu, 15 May 2025 17:19:06 +0200},
+      biburl       = {https://dblp.org/rec/conf/iclr/0002XCL0Z25.bib},
+      bibsource    = {dblp computer science bibliography, https://dblp.org}
+    }

--- a/papers/Zhao26smoothness-nonclairvoyant-scheduling.yml
+++ b/papers/Zhao26smoothness-nonclairvoyant-scheduling.yml
@@ -1,0 +1,18 @@
+title: On Smoothness Bounds for Non-Clairvoyant Scheduling with Predictions
+authors: Tianming Zhao, Albert Y. Zomaya
+labels:
+- online
+- scheduling
+publications:
+- name: ICLR
+  url: https://openreview.net/forum?id=Zcn4n57lHg
+  year: 2026
+  bibtex: |
+    @inproceedings{ZhaoZ26Smoothness,
+      author    = {Tianming Zhao and Albert Y. Zomaya},
+      title     = {On Smoothness Bounds for Non-Clairvoyant Scheduling with Predictions},
+      booktitle = {The Fourteenth International Conference on Learning Representations},
+      year      = {2026},
+      publisher = {OpenReview.net},
+      url       = {https://openreview.net/forum?id=Zcn4n57lHg}
+    }


### PR DESCRIPTION
## Summary

This PR adds four papers on algorithms with predictions in online scheduling and online portfolio selection:

- Competitive Fair Scheduling with Predictions — ICLR 2025
- On Smoothness Bounds for Non-Clairvoyant Scheduling with Predictions — ICLR 2026
- ATLAS: Alibaba Dataset and Benchmark for Learning-Augmented Scheduling — ICLR 2026
- Online Portfolio Selection with ML Predictions — NeurIPS 2025

The entries use existing ALPS labels and link to the official conference or OpenReview pages.

## Validation

- Verified titles, authors, venues, and publication years against the official conference pages.
- Successfully ran `npm run build`.