### PR TITLE
Add paper: Knowing Who, Not How Much

### DIFF
--- a/papers/Goldner26knowing-who-not-how-much.yml
+++ b/papers/Goldner26knowing-who-not-how-much.yml
@@ -1,0 +1,15 @@
+title: 'Knowing Who, Not How Much: Learning-Augmented Mechanisms for Consumer Utility Maximization'
+authors: Kira Goldner, Divyarthi Mohan, Thodoris Tsilivis
+labels:
+- online
+- game theory / mechanism design
+- auctions
+publications:
+- name: ICML
+  url: https://icml.cc/virtual/2026/poster/61658
+  year: 2026
+- name: arXiv
+  url: https://arxiv.org/abs/2607.00175
+  year: 2026
+  month: 6
+  day: 30


### PR DESCRIPTION
## Summary

Adds the ICML 2026 paper “Knowing Who, Not How Much: Learning-Augmented Mechanisms for Consumer Utility Maximization” by Kira Goldner, Divyarthi Mohan, and Thodoris Tsilivis.

The entry links to the official ICML page and arXiv record and uses the existing labels:
- `online`
- `game theory / mechanism design`
- `auctions`

## Validation

- Verified the title, authors, venue, and submission date against arXiv and ICML.
- Confirmed both publication URLs return HTTP 200.
- Successfully ran `npm run build`.